### PR TITLE
Failed to schedule

### DIFF
--- a/nhd/NHDCommon.py
+++ b/nhd/NHDCommon.py
@@ -38,3 +38,4 @@ class NHDCommon:
 
 class RpcMsgType(Enum):
     TYPE_NODE_INFO = 1     
+    TYPE_SCHEDULER_INFO = 2

--- a/nhd/NHDRpcServer.py
+++ b/nhd/NHDRpcServer.py
@@ -77,4 +77,18 @@ class NHDRpcHandler(nhd_stats_pb2_grpc.NHDControlServicer):
         
         return rsp
 
+    def GetSchedulerStats(self, request, context):
+        self.logger.info('Getting scheduler stats')
+        rsp = nhd_stats_pb2.SchedulerStats(status = nhd_stats_pb2.NHD_STATUS_ERR)
+
+        tmpq = Queue()
+        self.mainq.put((RcpMsgType.TYPE_SCHEDULER_INFO, tmpq))
+        try:
+            item = tmpq.get(True, 5)
+            rsp.status = nhd_status_pb2.NHD_STATUS_OK
+            rsp.failed_schedule_count = item
+        except Empty as e:
+            self.logger.error(f'Failed to get a response from NHD scheduler for Scheduler stats query: {e}')
+
+        return rsp
 

--- a/nhd/NHDScheduler.py
+++ b/nhd/NHDScheduler.py
@@ -353,6 +353,7 @@ class NHDScheduler(threading.Thread):
             q.put(rsp)
         elif msgid == RpcMsgType.TYPE_SCHEDULER_INFO:
             rsp = self.failed_schedule_count
+            self.failed_schedule_count = 0
             q.put(rsp)
 
     def run(self):

--- a/nhd/proto/nhd_stats.proto
+++ b/nhd/proto/nhd_stats.proto
@@ -33,6 +33,12 @@ message NodeStats {
     repeated NodeInfo info = 2;
 }
 
+message SchedulerStats {
+    NHDStatus status = 1;
+    uint32 failed_schedule_count = 2;
+}
+
 service NHDControl {
     rpc GetBasicNodeStats (Empty) returns (NodeStats) {}
+    rpc GetSchedulerStats (Empty) returns (SchedulerStats) {}
 }


### PR DESCRIPTION
Increments a counter after a pod is failed to be scheduled.
Exposes the counter via gRPC.
Resets the counter when the value is reported in gRPC (so that the reported value is the number of failed events since the last time it was queried).

Not tested - does not include compiled proto.