### PR TITLE
NHD to detect node deletions

### DIFF
--- a/nhd/NHDScheduler.py
+++ b/nhd/NHDScheduler.py
@@ -475,6 +475,17 @@ class NHDScheduler(threading.Thread):
 
                 continue
 
+            # Node deletion event
+            if item["type"] == NHDWatchTypes.NHD_WATCH_TYPE_TRIAD_NODE_DELETE:
+                for n, v in self.nodes.items():
+                    if n == item["node"]:
+                        self.logger.info(f'Deleting Node {n} from NHD node list')
+                        try:
+                            del self.nodes[n]
+                        except KeyError as e:
+                            self.logger.error(f'Failed to delete node {n} from NHD node list!')
+                        break
+
             # Pod creation/deletion events
             if item["type"] in (NHDWatchTypes.NHD_WATCH_TYPE_TRIAD_POD_DELETE,
                                 NHDWatchTypes.NHD_WATCH_TYPE_TRIAD_POD_CREATE):

--- a/nhd/NHDWatchQueue.py
+++ b/nhd/NHDWatchQueue.py
@@ -13,6 +13,7 @@ class NHDWatchTypes(Enum):
     NHD_WATCH_TYPE_GROUP_UPDATE = 7,
     NHD_WATCH_TYPE_NODE_MAINT_START = 8,
     NHD_WATCH_TYPE_NODE_MAINT_END = 9,
+    NHD_WATCH_TYPE_TRIAD_NODE_DELETE = 10,
 
 
 class NHDWatchQueue(object):
@@ -36,5 +37,5 @@ class NHDWatchQueue(object):
         return self.nqueue.qsize()
 
 
-  
+
 qinst = NHDWatchQueue()

--- a/nhd/TriadController.py
+++ b/nhd/TriadController.py
@@ -37,6 +37,14 @@ def delete_fn(meta, **_):
     logger.info('Received delete request for TriadSet')
 
 
+# Detect node deletion event
+@kopf.on.delete('','v1','nodes')
+def TriadNodeDelete(meta, **_):
+    logger = NHDCommon.GetLogger(__name__)
+    logger.info('K8s node deletion detected: %s', (meta["name"]))
+    k8sq = qinst
+    k8sq.put({"type": NHDWatchTypes.NHD_WATCH_TYPE_TRIAD_NODE_DELETE, "node": meta["name"]})
+
 # Detect node changes to determine if a node is cordoned and/or the NHD group label is changing
 @kopf.on.update('', 'v1', 'nodes')
 def TriadNodeUpdate(spec, old, new, meta, **_):
@@ -82,6 +90,8 @@ def TriadNodeUpdate(spec, old, new, meta, **_):
     elif (oldMaintenance and not newMaintenance):
         logger.info(f'Ending Maintenance for node {meta["name"]}')
         k8sq.put({"type": NHDWatchTypes.NHD_WATCH_TYPE_NODE_MAINT_END, "node": meta["name"]})
+
+
 
 
 # Timer acting as the TriadSet controller. Pods under the set are only created here either by a new set appearing, or an


### PR DESCRIPTION
 Detect node deletion events
 
    Technical details:
    1. Triad operator detects node deletion events via  kopf framework event.
    2. Node deletion signal gets sent to the NHD Scheduler process
    3. NHD deletes the node from the schedulable node list